### PR TITLE
Add basic orders API

### DIFF
--- a/controllers/order.go
+++ b/controllers/order.go
@@ -1,0 +1,176 @@
+package controllers
+
+import (
+	"context"
+	"dog/condb"
+	"dog/models"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v4"
+)
+
+// GenerateNextOrderID creates the next incremental order ID using ORD prefix
+func GenerateNextOrderID(conn *pgx.Conn) (string, error) {
+	var lastID string
+
+	err := conn.QueryRow(context.Background(),
+		`SELECT order_id FROM orders ORDER BY id DESC LIMIT 1`,
+	).Scan(&lastID)
+
+	if err != nil {
+		if err.Error() == "no rows in result set" {
+			return "ORD001", nil
+		}
+		return "", err
+	}
+
+	numPart := strings.TrimPrefix(lastID, "ORD")
+	num, err := strconv.Atoi(numPart)
+	if err != nil {
+		return "", fmt.Errorf("invalid order_id format in DB: %v", lastID)
+	}
+
+	newNum := num + 1
+	newOrderID := fmt.Sprintf("ORD%03d", newNum)
+	return newOrderID, nil
+}
+
+// CreateOrder inserts a new order record
+func CreateOrder(c *fiber.Ctx) error {
+	conn, err := condb.DB_Lek()
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "DB connection failed"})
+	}
+	defer conn.Close(context.Background())
+
+	newOrderID, err := GenerateNextOrderID(conn)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	var order models.Order
+	if err := c.BodyParser(&order); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid request"})
+	}
+
+	order.OrderID = newOrderID
+
+	_, err = conn.Exec(context.Background(),
+		`INSERT INTO orders (order_id, customer_id, total_price, status) VALUES ($1,$2,$3,$4)`,
+		order.OrderID, order.CustomerID, order.TotalPrice, order.Status,
+	)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	return c.Status(fiber.StatusCreated).JSON(fiber.Map{
+		"message":  "Order created",
+		"order_id": newOrderID,
+	})
+}
+
+// GetOrders returns all orders
+func GetOrders(c *fiber.Ctx) error {
+	conn, err := condb.DB_Lek()
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "DB connection failed"})
+	}
+	defer conn.Close(context.Background())
+
+	rows, err := conn.Query(context.Background(),
+		`SELECT id, order_id, customer_id, total_price, order_date, status, created_at FROM orders ORDER BY id ASC`,
+	)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+	defer rows.Close()
+
+	var orders []models.Order
+	for rows.Next() {
+		var o models.Order
+		if err := rows.Scan(&o.ID, &o.OrderID, &o.CustomerID, &o.TotalPrice, &o.OrderDate, &o.Status, &o.CreatedAt); err != nil {
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		}
+		orders = append(orders, o)
+	}
+
+	return c.JSON(orders)
+}
+
+// GetOrderByID returns a single order by its ID
+func GetOrderByID(c *fiber.Ctx) error {
+	conn, err := condb.DB_Lek()
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "DB connection failed"})
+	}
+	defer conn.Close(context.Background())
+
+	orderID := c.Params("order_id")
+
+	var o models.Order
+	err = conn.QueryRow(context.Background(),
+		`SELECT id, order_id, customer_id, total_price, order_date, status, created_at FROM orders WHERE order_id = $1`, orderID,
+	).Scan(&o.ID, &o.OrderID, &o.CustomerID, &o.TotalPrice, &o.OrderDate, &o.Status, &o.CreatedAt)
+	if err != nil {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "Order not found"})
+	}
+
+	return c.JSON(o)
+}
+
+// UpdateOrder updates order information
+func UpdateOrder(c *fiber.Ctx) error {
+	conn, err := condb.DB_Lek()
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "DB connection failed"})
+	}
+	defer conn.Close(context.Background())
+
+	orderID := c.Params("order_id")
+
+	var updateData models.Order
+	if err := c.BodyParser(&updateData); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid request"})
+	}
+
+	commandTag, err := conn.Exec(context.Background(),
+		`UPDATE orders SET customer_id=$1, total_price=$2, status=$3 WHERE order_id=$4`,
+		updateData.CustomerID, updateData.TotalPrice, updateData.Status, orderID,
+	)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	if commandTag.RowsAffected() == 0 {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "Order not found"})
+	}
+
+	return c.JSON(fiber.Map{"message": "Order updated successfully"})
+}
+
+// DeleteOrder removes an order by ID
+func DeleteOrder(c *fiber.Ctx) error {
+	conn, err := condb.DB_Lek()
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "DB connection failed"})
+	}
+	defer conn.Close(context.Background())
+
+	orderID := c.Params("order_id")
+
+	commandTag, err := conn.Exec(context.Background(),
+		`DELETE FROM orders WHERE order_id=$1`, orderID,
+	)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	if commandTag.RowsAffected() == 0 {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "Order not found"})
+	}
+
+	return c.JSON(fiber.Map{"message": "Order deleted successfully"})
+}

--- a/models/order.go
+++ b/models/order.go
@@ -1,0 +1,16 @@
+package models
+
+import "time"
+
+// Order represents a customer order
+// OrderID uses format ORD001 with incremental numbering
+// Status can hold order state like pending, shipped, etc.
+type Order struct {
+	ID         int       `json:"id"`
+	OrderID    string    `json:"order_id"`
+	CustomerID string    `json:"customer_id"`
+	TotalPrice float64   `json:"total_price"`
+	OrderDate  time.Time `json:"order_date"`
+	Status     string    `json:"status"`
+	CreatedAt  time.Time `json:"created_at"`
+}

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -43,6 +43,13 @@ func RegisterRoutes(app *fiber.App) {
 	app.Get("/customers/:customer_id", controllers.GetCustomerByID)
 	app.Put("/customers/:customer_id", controllers.UpdateCustomer)
 
+	// orders
+	app.Post("/orders", controllers.CreateOrder)
+	app.Get("/orders", controllers.GetOrders)
+	app.Get("/orders/:order_id", controllers.GetOrderByID)
+	app.Put("/orders/:order_id", controllers.UpdateOrder)
+	app.Delete("/orders/:order_id", controllers.DeleteOrder)
+
 	//hero-slider
 	app.Get("/hero-slider", popular.Popular)
 	app.Post("/hero-slider", popular.AddPopular)


### PR DESCRIPTION
## Summary
- add Order model for storing customer orders
- implement controller functions and routes for creating, listing, retrieving, updating and deleting orders

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a580747dd48328a89d1e388b9dfa5b