### PR TITLE
Add HTML page for order API

### DIFF
--- a/static/orders.html
+++ b/static/orders.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Order API Demo</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        section { margin-bottom: 40px; }
+        label { display: block; margin-top: 8px; }
+        textarea, input { width: 100%; }
+        pre { background: #f4f4f4; padding: 10px; }
+    </style>
+</head>
+<body>
+<h1>Order API Demo</h1>
+
+<section id="create">
+    <h2>Create Order</h2>
+    <label>JWT Token
+        <input id="createToken" type="text" placeholder="Bearer token">
+    </label>
+    <label>Order JSON
+        <textarea id="createBody" rows="5" placeholder='{"payment_method":"COD","items":[{"product_id":"1","quantity":1}]}'></textarea>
+    </label>
+    <button onclick="createOrder()">Create</button>
+    <pre id="createResult"></pre>
+</section>
+
+<section id="list">
+    <h2>Get Orders</h2>
+    <button onclick="getOrders()">Fetch Orders</button>
+    <pre id="listResult"></pre>
+</section>
+
+<section id="getById">
+    <h2>Get Order by ID</h2>
+    <label>Order ID
+        <input id="getId" type="text" placeholder="1">
+    </label>
+    <button onclick="getOrderById()">Fetch Order</button>
+    <pre id="getResult"></pre>
+</section>
+
+<section id="update">
+    <h2>Update Order</h2>
+    <label>Order ID
+        <input id="updateId" type="text" placeholder="1">
+    </label>
+    <label>Update JSON
+        <textarea id="updateBody" rows="3" placeholder='{"status":"shipped"}'></textarea>
+    </label>
+    <button onclick="updateOrder()">Update</button>
+    <pre id="updateResult"></pre>
+</section>
+
+<section id="delete">
+    <h2>Delete Order</h2>
+    <label>Order ID
+        <input id="deleteId" type="text" placeholder="1">
+    </label>
+    <button onclick="deleteOrder()">Delete</button>
+    <pre id="deleteResult"></pre>
+</section>
+
+<script>
+const API = location.origin;
+
+async function createOrder() {
+    const token = document.getElementById('createToken').value;
+    const body = document.getElementById('createBody').value;
+    const res = await fetch(`${API}/orders`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': token
+        },
+        body: body
+    });
+    document.getElementById('createResult').textContent = await res.text();
+}
+
+async function getOrders() {
+    const res = await fetch(`${API}/orders`);
+    document.getElementById('listResult').textContent = await res.text();
+}
+
+async function getOrderById() {
+    const id = document.getElementById('getId').value;
+    const res = await fetch(`${API}/orders/${id}`);
+    document.getElementById('getResult').textContent = await res.text();
+}
+
+async function updateOrder() {
+    const id = document.getElementById('updateId').value;
+    const body = document.getElementById('updateBody').value;
+    const res = await fetch(`${API}/orders/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: body
+    });
+    document.getElementById('updateResult').textContent = await res.text();
+}
+
+async function deleteOrder() {
+    const id = document.getElementById('deleteId').value;
+    const res = await fetch(`${API}/orders/${id}`, { method: 'DELETE' });
+    document.getElementById('deleteResult').textContent = await res.text();
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple HTML demo page to interact with order endpoints

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a594e627c483288a72b487ab334136